### PR TITLE
Prevent rebooking unbooked teams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "fw-team-sniper",
+  "name": "puregym-team-sniper",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "fw-team-sniper",
+      "name": "puregym-team-sniper",
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "ISC",

--- a/src/clients/logging-client.ts
+++ b/src/clients/logging-client.ts
@@ -1,0 +1,32 @@
+import { promises as fsPromises } from 'fs';
+
+const LOGGING_FILE_NAME = 'bookings.log';
+
+export class LoggingClient {
+
+  constructor() {
+    // Create the logging file if it does not exist
+    fsPromises.open(LOGGING_FILE_NAME, 'a').catch();
+  }
+
+  async isFirstTimeBooked(id: string): Promise<boolean> {
+    const existingIds = await this.readIdsFromFileAsync();
+
+    if (existingIds.has(id)) {
+      return false;
+    }
+
+    // Add the new ID to the Set and add write it to the file    
+    existingIds.add(id);
+    await fsPromises.writeFile(LOGGING_FILE_NAME, Array.from(existingIds).join('\n'));
+
+    return true;
+  }
+
+  private async readIdsFromFileAsync(): Promise<Set<string>> {
+    const content = await fsPromises.readFile(LOGGING_FILE_NAME, 'utf-8');
+    // Split the content into an array of IDs and convert to Set
+    return new Set(content.trim().split('\n'));
+  }
+}
+


### PR DESCRIPTION
If you schedule a sniper and manually unbook in your app, the sniper will continue to target and book even after you've unbooked. This feature ensures that a team is booked only once.